### PR TITLE
light blue additions

### DIFF
--- a/MyMarkers1.html
+++ b/MyMarkers1.html
@@ -47,7 +47,7 @@
                     if(aircraft.operator.val.match(/fire/i)) {
                     return "#CE5200";  // orange
                     }
-					if(aircraft.operator.val.match(/air med|airmed|med-trans|medevac|ambulance|adac/i)) {
+					if(aircraft.operator.val.match(/air med|airmed|med-trans|medevac|ambulance|hospital|medical|adac/i)) {
                     return "#99d0ea";  // light blue
                     }
 					if(aircraft.operator.val.match(/draken|gfd|top aces|airborne tactical advantage|Air USA|coastal defense|tactical air support|meta aerospace|aec skyline aviation|aviation defence service|spanish maritime rescue/i)) {


### PR DESCRIPTION
Add `hospital` and `medical` to light blue markers. Having looked through the db, planes with these keywords in the operator name are probably gonna be medical flights